### PR TITLE
Tables.jl interface example and other tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.jl.cov
 *.jl.mem
 /Manifest.toml
-/docs/Manifest.toml
 /deps/deps.jl
+Manifest.toml
+.vscode/settings.json

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 DataStructures = "0.18.22"
@@ -20,6 +21,7 @@ Optim = "1.12.0"
 Plots = "1.40.13"
 Polynomials = "4.0.19"
 Statistics = "1.11.1"
+Tables = "1"
 julia = "1.11"
 
 [extras]

--- a/src/Models/ExponentialSmoothing/ExponentialSmoothing.jl
+++ b/src/Models/ExponentialSmoothing/ExponentialSmoothing.jl
@@ -7,11 +7,13 @@ import Statistics: mean
 using Plots
 using Polynomials
 using Distributions
+using Tables
 import DataStructures: OrderedDict
 
 # Internal modules
 import ..Utils: is_constant, match_arg, na_action, na_omit
-import ..Stats: box_cox_lambda, box_cox, inv_box_cox, decompose, DecomposedTimeSeries, diff, fourier
+import ..Stats:
+    box_cox_lambda, box_cox, inv_box_cox, decompose, DecomposedTimeSeries, diff, fourier
 import ..Generics: Forecast, forecast, plot
 import ..Optimize: nmmin, NelderMeadOptions
 

--- a/src/Models/ExponentialSmoothing/holt_winters.jl
+++ b/src/Models/ExponentialSmoothing/holt_winters.jl
@@ -48,11 +48,17 @@ function holt_winters(
     end
 
     if length(y) <= m + 3
-        throw(ArgumentError("I need at least $(m + 3) observations to estimate seasonality."))
+        throw(
+            ArgumentError("I need at least $(m + 3) observations to estimate seasonality."),
+        )
     end
 
     if seasonal == "additive" && exponential
-        throw(ArgumentError("Forbidden model combination: additive seasonality with exponential trend."))
+        throw(
+            ArgumentError(
+                "Forbidden model combination: additive seasonality with exponential trend.",
+            ),
+        )
     end
 
     model_code = ""
@@ -127,4 +133,44 @@ function holt_winters(
         model.fit,
         method,
     )
+end
+
+"""
+    holt_winters(table, m::Int; kwargs...)
+
+Tables.jl interface for Holt-Winters exponential smoothing.
+
+This function accepts any Tables.jl-compatible table as the time series data to be used 
+for Holt-Winters forecasting.
+
+# Arguments
+- `table`: Any Tables.jl-compatible table (DataFrame, NamedTuple of columns, etc.)
+- `m::Int`: The seasonal period (frequency) of the time series
+- `col::Union{String,Symbol,Nothing}`: (optional) The name of the column to use as the time series. 
+  If not provided, the first column of the table will be used.
+- `kwargs...`: All other keyword arguments are passed to the main `holt_winters` function
+
+# Returns
+- `HoltWinters`: A fitted Holt-Winters model
+"""
+function holt_winters(table, m::Int; col::Union{String,Symbol,Nothing} = nothing, kwargs...)
+    if !Tables.istable(table)
+        throw(ArgumentError("Input must be a Tables.jl-compatible table"))
+    end
+
+    # extract columns from the table
+    columns = Tables.columns(table)
+    col_names = Tables.columnnames(columns)
+
+    if isempty(col_names)
+        throw(ArgumentError("Table must have at least one column"))
+    end
+
+    # if col is not specified, use the first column
+    if isnothing(col)
+        col = first(col_names)
+    end
+    y = Tables.getcolumn(columns, Symbol(col))
+
+    return holt_winters(collect(y), m; kwargs...)
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Durbyn = "40b042de-e8ce-4d84-a20a-09ad0ba5d568"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,1 +1,22 @@
+using Durbyn
+using Test
+using DataFrames
 
+#=
+Don't add your tests to runtests.jl. Instead, create files named
+
+    test-title-for-my-test.jl
+
+The file will be automatically included inside a `@testset` with title "Title For My Test".
+=#
+for (root, dirs, files) in walkdir(@__DIR__)
+    for file in files
+        if isnothing(match(r"^test-.*\.jl$", file))
+            continue
+        end
+        title = titlecase(replace(splitext(file[6:end])[1], "-" => " "))
+        @testset "$title" begin
+            include(file)
+        end
+    end
+end

--- a/test/test-tables-interface.jl
+++ b/test/test-tables-interface.jl
@@ -1,0 +1,44 @@
+"""Unit tests for Tables.jl interface in holt_winters function."""
+
+using Durbyn.ExponentialSmoothing: holt_winters, HoltWinters
+using Durbyn: air_passengers
+
+@testset "Tables.jl Interface Tests" begin
+
+    @testset "holt_winters Tables.jl NamedTuple" begin
+        ap = air_passengers()
+        table_nt = (ap = ap,)
+        model_nt = holt_winters(table_nt, 12)
+
+        # test that it returns a HoltWinters object
+        @test model_nt isa Durbyn.ExponentialSmoothing.HoltWinters
+
+        # test that it produces the same result as the array version
+        model_array = holt_winters(ap, 12)
+        @test model_nt.fitted == model_array.fitted
+        @test model_nt.residuals == model_array.residuals
+        @test model_nt.aic == model_array.aic
+    end
+
+    @testset "holt_winters Tables.jl DataFrame" begin
+        ap = air_passengers()
+        df = DataFrame(ap = ap)
+        model_df = holt_winters(df, 12)
+
+        # test that it returns a HoltWinters object
+        @test model_df isa Durbyn.ExponentialSmoothing.HoltWinters
+
+        # test that it produces the same result as the array version
+        model_array = holt_winters(ap, 12)
+        @test model_df.fitted == model_array.fitted
+        @test model_df.residuals == model_array.residuals
+        @test model_df.aic == model_array.aic
+
+        # specify column name
+        model_df_col = holt_winters(df, 12; col = "ap")
+        @test model_df_col.fitted == model_array.fitted
+        @test model_df_col.residuals == model_array.residuals
+        @test model_df_col.aic == model_array.aic
+    end
+
+end


### PR DESCRIPTION
This PR shows how to use the [Tables.jl interface](https://tables.juliadata.org/stable/using-the-interface/#Using-the-Interface-(i.e.-consuming-Tables.jl-compatible-sources)). 

It also adds `runtests.jl` so you can run unit tests from `Pkg` using `] test`.